### PR TITLE
Background image overflow fix

### DIFF
--- a/web/themes/custom/karaoke_2022/components/05-pages/bkg/_bkg.scss
+++ b/web/themes/custom/karaoke_2022/components/05-pages/bkg/_bkg.scss
@@ -13,6 +13,9 @@ $colors: (#3d0a91, #801f4f, #997306);
 .background {
   width: 100vw;
   height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Purpose:
- The strobing background image was causing some overflow issues (adding a moving scrollbar)

### Pull Request Deployment:
See linked environment in comments.

### Functional Testing:
- [ ] Visit a page on the site
- [ ] Note that you no longer have a moving horizontal and vertical scrollbar (tested in Firefox)
