### PR TITLE
Standardizing fieldset headers so they work with ajax

### DIFF
--- a/web/themes/custom/karaoke_2022/components/01-atoms/forms/_fieldset.scss
+++ b/web/themes/custom/karaoke_2022/components/01-atoms/forms/_fieldset.scss
@@ -1,0 +1,7 @@
+
+fieldset legend.h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  font-family: $font-family-base;
+  text-transform: uppercase;
+}

--- a/web/themes/custom/karaoke_2022/components/02-molecules/song-book/_song-book.scss
+++ b/web/themes/custom/karaoke_2022/components/02-molecules/song-book/_song-book.scss
@@ -42,8 +42,3 @@
     margin-right: 1rem;
   }
 }
-
-fieldset#edit-sort-by--wrapper legend.h2 {
-  font-size: 1rem;
-  text-transform: uppercase;
-}

--- a/web/themes/custom/karaoke_2022/components/style.scss
+++ b/web/themes/custom/karaoke_2022/components/style.scss
@@ -6,6 +6,14 @@
 @import '~bootstrap/scss/mixins/banner';
 // @include bsBanner('');
 
+// Configuration
+@import '~bootstrap/scss/functions';
+@import './vars';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/maps';
+@import '~bootstrap/scss/mixins';
+@import '~bootstrap/scss/utilities';
+
 // Components
 @import '00-base/**/*.scss';
 @import '01-atoms/**/*.scss';
@@ -18,14 +26,6 @@
 //@import '00-base/00-defaults/_03-mixins.scss';
 //@import '01-atoms/buttons/_buttons.scss';
 //@import '01-atoms/lists/list';
-
-// Configuration
-@import '~bootstrap/scss/functions';
-@import './vars';
-@import '~bootstrap/scss/variables';
-@import '~bootstrap/scss/maps';
-@import '~bootstrap/scss/mixins';
-@import '~bootstrap/scss/utilities';
 
 // Layout & components
 @import '~bootstrap/scss/root';


### PR DESCRIPTION
## Purpose:
- Fixes the radio button headers so they are styled conisistantly after ajax and follows the formatting of other labels.

### Functional Testing:
- [ ] Navigate to the home page.
- [ ] Validate that the SORT label looks like similar to "Search by Song or Artist"
- [ ] select one of the radio buttons
- [ ] Validate that the SORT label doesn't switch to standard h2 styling
- [ ] Click Request
- [ ] Validate that the "WHO'S SINGING?" label looks similar to "Singing as:"
![image](https://user-images.githubusercontent.com/526491/198062951-001ec4d8-6289-40c2-b4b6-3dbdf8b33264.png)
![image](https://user-images.githubusercontent.com/526491/198062995-79162c39-5a2f-4e77-9845-8e2580be0c93.png)


